### PR TITLE
Use default text editor and gtk4

### DIFF
--- a/extension/nautilus-admin.py
+++ b/extension/nautilus-admin.py
@@ -15,99 +15,96 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os, subprocess
+import locale
+import os
+import subprocess
+from gettext import gettext, bindtextdomain, textdomain
 
-from gi import require_version
-require_version('Gtk', '3.0')
-require_version('Nautilus', '3.0')
-
-from gi.repository import Nautilus, GObject
-from gettext import gettext, locale, bindtextdomain, textdomain
+from gi.repository import Nautilus, GObject, Gio
 
 ROOT_UID = 0
-NAUTILUS_PATH="@NAUTILUS_PATH@"
-GEDIT_PATH="@GEDIT_PATH@"
+NAUTILUS_PATH = "/usr/bin/nautilus"
+
 
 class NautilusAdmin(Nautilus.MenuProvider, GObject.GObject):
-	"""Simple Nautilus extension that adds some administrative (root) actions to
-	the right-click menu, using GNOME's new admin backend."""
-	def __init__(self):
-		pass
+    """Simple Nautilus extension that adds some administrative (admin) actions to
+    the right-click menu, using GNOME's new admin backend."""
 
-	def get_file_items(self, window, files):
-		"""Returns the menu items to display when one or more files/folders are
-		selected."""
-		# Don't show when already running as root, or when more than 1 file is selected
-		if os.geteuid() == ROOT_UID or len(files) != 1:
-			return
-		file = files[0]
+    def __init__(self):
+        pass
 
-		# Add the menu items
-		items = []
-		self._setup_gettext();
-		self.window = window
-		if file.get_uri_scheme() == "file": # must be a local file/directory
-			if file.is_directory():
-				if os.path.exists(NAUTILUS_PATH):
-					items += [self._create_nautilus_item(file)]
-			else:
-				if os.path.exists(GEDIT_PATH):
-					items += [self._create_gedit_item(file)]
+    def get_file_items(self, files):
+        """Returns the menu items to display when one or more files/folders are
+        selected."""
+        # Don't show when already running as admin, or when more than 1 file is selected
+        if os.geteuid() == ROOT_UID or len(files) != 1:
+            return
+        file = files[0]
 
-		return items
+        # Add the menu items
+        items = []
+        self._setup_gettext()
+        if file.get_uri_scheme() == "file":  # must be a local file/directory
+            if file.is_directory():
+                if os.path.exists(NAUTILUS_PATH):
+                    items += [self._create_nautilus_item(file)]
+            else:
+                items += [self._create_edit_file_as_admin_item(file)]
 
-	def get_background_items(self, window, file):
-		"""Returns the menu items to display when no file/folder is selected
-		(i.e. when right-clicking the background)."""
-		# Don't show when already running as root
-		if os.geteuid() == ROOT_UID:
-			return
+        return items
 
-		# Add the menu items
-		items = []
-		self._setup_gettext();
-		self.window = window
-		if file.is_directory() and file.get_uri_scheme() == "file":
-			if os.path.exists(NAUTILUS_PATH):
-				items += [self._create_nautilus_item(file)]
+    def get_background_items(self, file):
+        """Returns the menu items to display when no file/folder is selected
+        (i.e. when right-clicking the background)."""
+        # Don't show when already running as admin
+        if os.geteuid() == ROOT_UID:
+            return
 
-		return items
+        # Add the menu items
+        items = []
+        self._setup_gettext()
+        if file.is_directory() and file.get_uri_scheme() == "file":
+            if os.path.exists(NAUTILUS_PATH):
+                items += [self._create_nautilus_item(file)]
 
+        return items
 
-	def _setup_gettext(self):
-		"""Initializes gettext to localize strings."""
-		try: # prevent a possible exception
-			locale.setlocale(locale.LC_ALL, "")
-		except:
-			pass
-		bindtextdomain("nautilus-admin", "@CMAKE_INSTALL_PREFIX@/share/locale")
-		textdomain("nautilus-admin")
+    def _setup_gettext(self):
+        """Initializes gettext to localize strings."""
+        try:  # prevent a possible exception
+            locale.setlocale(locale.LC_ALL, "")
+        except:
+            pass
+        bindtextdomain("nautilus-admin", "@CMAKE_INSTALL_PREFIX@/share/locale")
+        textdomain("nautilus-admin")
 
-	def _create_nautilus_item(self, file):
-		"""Creates the 'Open as Administrator' menu item."""
-		item = Nautilus.MenuItem(name="NautilusAdmin::Nautilus",
-		                         label=gettext("Open as A_dministrator"),
-		                         tip=gettext("Open this folder with root privileges"))
-		item.connect("activate", self._nautilus_run, file)
-		return item
+    def _nautilus_run(self, _, file):
+        """'Open as Administrator' menu item callback."""
+        uri = file.get_uri()
+        admin_uri = uri.replace("file://", "admin://")
+        subprocess.Popen([NAUTILUS_PATH, admin_uri])
 
-	def _create_gedit_item(self, file):
-		"""Creates the 'Edit as Administrator' menu item."""
-		item = Nautilus.MenuItem(name="NautilusAdmin::Gedit",
-		                         label=gettext("Edit as A_dministrator"),
-		                         tip=gettext("Open this file in the text editor with root privileges"))
-		item.connect("activate", self._gedit_run, file)
-		return item
+    def _create_nautilus_item(self, file):
+        """Creates the 'Open as Administrator' menu item."""
+        item = Nautilus.MenuItem(name="NautilusAdmin::Nautilus",
+                                 label=gettext("Open as admin"),
+                                 tip=gettext("Open this folder with admin privileges"))
+        item.connect("activate", self._nautilus_run, file)
+        return item
 
+    def _create_edit_file_as_admin_item(self, file):
+        """Creates the 'Edit as Administrator' menu item."""
+        item = Nautilus.MenuItem(name="NautilusAdmin::TextEditor",
+                                 label=gettext("Edit as admin"),
+                                 tip=gettext("Open this file in the default text editor with admin privileges"))
+        item.connect("activate", self._edit_file, file)
+        return item
 
-	def _nautilus_run(self, menu, file):
-		"""'Open as Administrator' menu item callback."""
-		uri = file.get_uri()
-		admin_uri = uri.replace("file://", "admin://")
-		subprocess.Popen([NAUTILUS_PATH, admin_uri])
-
-	def _gedit_run(self, menu, file):
-		"""'Edit as Administrator' menu item callback."""
-		uri = file.get_uri()
-		admin_uri = uri.replace("file://", "admin://")
-		subprocess.Popen([GEDIT_PATH, admin_uri])
+    def _edit_file(self, _, file):
+        """'Edit as Administrator' menu item callback."""
+        uri = file.get_uri()
+        admin_uri = uri.replace("file://", "admin://")
+        content_type = Gio.content_type_guess()
+        text_editor = Gio.app_info_get_default_for_type(content_type[0], True).get_executable()
+        if text_editor is not None:
+            subprocess.Popen([text_editor, admin_uri])

--- a/extension/nautilus-admin.py
+++ b/extension/nautilus-admin.py
@@ -22,7 +22,7 @@ from gettext import gettext, bindtextdomain, textdomain
 from gi.repository import Nautilus, GObject, Gio
 
 ROOT_UID = 0
-NAUTILUS_PATH = "/usr/bin/nautilus"
+NAUTILUS_PATH="@NAUTILUS_PATH@"
 
 
 class NautilusAdmin(Nautilus.MenuProvider, GObject.GObject):


### PR DESCRIPTION
Remove the hard coded path of the gedit and use the text editor to make it more convenient for those that use a third party text editor or gnome's new text editor named "Gnome Text Editor".